### PR TITLE
GridLayout is deprecated, and replaced by CollectionLayout, which breaks fview-flex, this patch is to fix this.

### DIFF
--- a/lib/pre.js
+++ b/lib/pre.js
@@ -11,8 +11,8 @@ var modules = [
   'LayoutController', 
   'ScrollController',
 
-  'layouts/GridLayout',
   'layouts/CollectionLayout',
+  'layouts/GridLayout',
   'layouts/ListLayout',
   'layouts/ProportionalLayout',
   'layouts/WheelLayout',

--- a/package.js
+++ b/package.js
@@ -24,8 +24,8 @@ Package.onUse(function(api) {
     'LayoutController', 
     'ScrollController',
 
-    'layouts/GridLayout',
     'layouts/CollectionLayout',
+    'layouts/GridLayout',
     'layouts/ListLayout',
     'layouts/ProportionalLayout',
     'layouts/WheelLayout',


### PR DESCRIPTION
Hi, when working with latest famous-flex, fview-flex will break, because of this latest code from GridLayout: 

```
define(function(require, exports, module) {
    if (console.warn) {
        console.warn('GridLayout has been deprecated and will be removed in the future, use CollectionLayout instead');
    }
    module.exports = require('./CollectionLayout');
});
```

As a quick fix, this patch just first loads CollectionLayout.
